### PR TITLE
Month and year picker ux improvement

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="p-3">
-    <DatePicker v-model="date" />
+    <DatePicker v-model="date" multi-month />
     {{ date }}
   </div>
 </template>

--- a/src/components/MultiView.vue
+++ b/src/components/MultiView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex w-full flex-col lg:flex-row">
+  <div class="flex w-full flex-col lg:flex-row" ref="multiViewRef">
     <div
       :class="{
         'bg-white': true,
@@ -52,6 +52,8 @@ import MonthWrapper from "./MonthWrapper.vue";
 import CalendarNavigation from "./CalendarNavigation.vue";
 import { rangeSelect, nextMonth, prevMonth } from "../utils/datepicker";
 import { ref, watch } from "vue";
+import { onClickOutside } from "@vueuse/core";
+
 const props = defineProps({
   ...AllProps,
 });
@@ -61,6 +63,8 @@ const emit = defineEmits(["update:modelValue"]);
 const firstCalendarToggleState = ref({ month: false, year: false });
 const secondCalendarToggleState = ref({ month: false, year: false });
 const firstCalendarMonthAndYear = ref({ month: props.month, year: props.year });
+const multiViewRef = ref(null);
+
 /** Passing month and year props to nextMonth method to ensure second calendar
  *  does not render same month and year as first calendat.
  */
@@ -161,4 +165,10 @@ watch(
     secondCalendarNav();
   }
 );
+
+/** Close month and year picker when clicked outside */
+onClickOutside(multiViewRef, () => {
+  closeFirstSelecter();
+  closeSecondSelecter();
+});
 </script>

--- a/src/components/SingleView.vue
+++ b/src/components/SingleView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bg-white rounded">
+  <div class="bg-white rounded" ref="singleViewRef">
     <CalendarNavigation
       v-model:month="selectedMonth"
       v-model:year="selectedYear"
@@ -23,6 +23,7 @@ import CalendarNavigation from "./CalendarNavigation.vue";
 import MonthWrapper from "./MonthWrapper.vue";
 import { AllProps } from "../utils/props";
 import { rangeSelect } from "../utils/datepicker";
+import { onClickOutside } from "@vueuse/core";
 
 const emit = defineEmits(["update:modelValue"]);
 
@@ -30,6 +31,7 @@ const monthPicker = ref(false);
 const yearPicker = ref(false);
 const selectedMonth = ref(props.month);
 const selectedYear = ref(props.year);
+const singleViewRef = ref(null);
 
 const props = defineProps({
   ...AllProps,
@@ -76,4 +78,9 @@ const closePicker = () => {
   monthPicker.value = false;
   yearPicker.value = false;
 };
+
+/** Close month and year picker when clicked outside */
+onClickOutside(singleViewRef, () => {
+  closePicker();
+});
 </script>

--- a/src/components/YearPicker.vue
+++ b/src/components/YearPicker.vue
@@ -32,5 +32,5 @@ const selectYear = (year) => {
 };
 
 /** Generates range of years provided */
-const years = computed(() => yearRange(1972, props.year));
+const years = computed(() => yearRange(1972, props.modelValue).reverse());
 </script>


### PR DESCRIPTION
- Sort years with recent years first.
- Close month and year picker on clicking outside.